### PR TITLE
Feature/ID-273 handle owner or everyone in access definitions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "web-token/jwt-signature-algorithm-rsa": "^2.1",
         "jms/serializer": "^3.8",
         "symfony/config": "^v4.4.13|^5.1.5",
-        "symfony/yaml": "^v4.4.13|^5.1.5"
+        "symfony/yaml": "^v4.4.13|^5.1.5",
+        "symfony/expression-language": "^v4.4.13|^5.1.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "933350a470259018ff4e04736d568353",
+    "content-hash": "cc5a11aa3c9afed41f27b82c7669c63f",
     "packages": [
         {
             "name": "brick/math",
@@ -637,6 +637,55 @@
             "time": "2020-08-26T07:23:26+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -829,6 +878,180 @@
                 "url"
             ],
             "time": "2020-08-30T13:35:33+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v5.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "d6aed6c1bbf6f59e521f46437475a0ff4878d388"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/d6aed6c1bbf6f59e521f46437475a0ff4878d388",
+                "reference": "d6aed6c1bbf6f59e521f46437475a0ff4878d388",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/cache": "~1.0",
+                "psr/log": "^1.1",
+                "symfony/cache-contracts": "^1.1.7|^2",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.10",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/http-kernel": "<4.4",
+                "symfony/var-dumper": "<4.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0",
+                "symfony/cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "^1.6",
+                "doctrine/dbal": "^2.10|^3.0",
+                "predis/predis": "^1.1",
+                "psr/simple-cache": "^1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/filesystem": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/messenger": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an extended PSR-6, PSR-16 (and tags) implementation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v5.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T11:24:50+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "8034ca0b61d4dd967f3698aaa1da2507b631d0cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/8034ca0b61d4dd967f3698aaa1da2507b631d0cb",
+                "reference": "8034ca0b61d4dd967f3698aaa1da2507b631d0cb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/cache": "^1.0"
+            },
+            "suggest": {
+                "symfony/cache-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/config",
@@ -1206,6 +1429,70 @@
                 }
             ],
             "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v5.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "7bf30a4e29887110f8bd1882ccc82ee63c8a5133"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/7bf30a4e29887110f8bd1882ccc82ee63c8a5133",
+                "reference": "7bf30a4e29887110f8bd1882ccc82ee63c8a5133",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/cache": "^4.4|^5.0",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an engine that can compile and evaluate expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/expression-language/tree/v5.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T10:15:41+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2778,6 +3065,79 @@
             "time": "2020-08-17T07:42:30+00:00"
         },
         {
+            "name": "symfony/var-exporter",
+            "version": "v5.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "5aed4875ab514c8cb9b6ff4772baa25fa4c10307"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/5aed4875ab514c8cb9b6ff4772baa25fa4c10307",
+                "reference": "5aed4875ab514c8cb9b6ff4772baa25fa4c10307",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^4.4.9|^5.0.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v5.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-27T10:01:46+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v5.1.5",
             "source": {
@@ -3381,5 +3741,5 @@
         "php": "^7.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/src/AccessDefinitions/JMS/ExpressionLanguage/AccessDefinitionExpressionLanguageProvider.php
+++ b/src/AccessDefinitions/JMS/ExpressionLanguage/AccessDefinitionExpressionLanguageProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace HalloVerden\Security\AccessDefinitions\JMS\ExpressionLanguage;
+
+use HalloVerden\Security\AccessDefinitions\JMS\ExpressionLanguage\ExpressionFunction\HasAccessFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+/**
+ * Class AccessDefinitionExpressionLanguageProvider
+ *
+ * @package HalloVerden\Security\AccessDefinitions\JMS\ExpressionLanguage
+ */
+class AccessDefinitionExpressionLanguageProvider implements ExpressionFunctionProviderInterface {
+
+  /**
+   * @var HasAccessFunction
+   */
+  private $hasAccessFunction;
+
+  /**
+   * HasAccessExpressionLanguageProvider constructor.
+   *
+   * @param HasAccessFunction $hasAccessFunction
+   */
+  public function __construct(HasAccessFunction $hasAccessFunction) {
+    $this->hasAccessFunction = $hasAccessFunction;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getFunctions(): array {
+    return [
+      new ExpressionFunction('hasAccess', function () {}, $this->hasAccessFunction)
+    ];
+  }
+
+}

--- a/src/AccessDefinitions/JMS/ExpressionLanguage/ExpressionFunction/HasAccessFunction.php
+++ b/src/AccessDefinitions/JMS/ExpressionLanguage/ExpressionFunction/HasAccessFunction.php
@@ -1,0 +1,127 @@
+<?php
+
+
+namespace HalloVerden\Security\AccessDefinitions\JMS\ExpressionLanguage\ExpressionFunction;
+
+use HalloVerden\Security\Interfaces\AccessDefinitionOwnerAwareInterface;
+use HalloVerden\Security\Interfaces\AccessDefinitionOwnerInterface;
+use HalloVerden\Security\Interfaces\AccessDefinitionServiceInterface;
+use JMS\Serializer\Context;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\SerializationContext;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Class HasAccessFunction
+ *
+ * @package App\ExpressionLanguageProviders\Functions
+ */
+class HasAccessFunction {
+
+  /**
+   * @var AccessDefinitionServiceInterface
+   */
+  private $accessDefinitionService;
+
+  /**
+   * @var TokenStorageInterface
+   */
+  private $tokenStorage;
+
+  /**
+   * HasAccessFunction constructor.
+   *
+   * @param AccessDefinitionServiceInterface $accessDefinitionService
+   * @param TokenStorageInterface            $tokenStorage
+   */
+  public function __construct(AccessDefinitionServiceInterface $accessDefinitionService, TokenStorageInterface $tokenStorage) {
+    $this->accessDefinitionService = $accessDefinitionService;
+    $this->tokenStorage = $tokenStorage;
+  }
+
+  /**
+   * @param $arguments
+   *
+   * @return bool
+   */
+  public function __invoke(array $arguments): bool {
+    return $this->hasAccess(...$this->checkArguments($arguments));
+  }
+
+  /**
+   * @param Context          $context
+   * @param PropertyMetadata $propertyMetadata
+   * @param object|null      $object $object
+   *
+   * @return bool
+   */
+  private function hasAccess(Context $context, PropertyMetadata $propertyMetadata, ?object $object): bool {
+    if ($context instanceof DeserializationContext) {
+      return $this->accessDefinitionService->canWriteProperty($propertyMetadata->class, $propertyMetadata->name, $this->isOwner($object));
+    } elseif ($context instanceof SerializationContext) {
+      return $this->accessDefinitionService->canReadProperty($propertyMetadata->class, $propertyMetadata->name, $this->isOwner($object));
+    }
+
+    return true;
+  }
+
+  /**
+   * @param object|null $object $object
+   *
+   * @return bool
+   */
+  private function isOwner(?object $object): bool {
+    if (!$object instanceof AccessDefinitionOwnerAwareInterface) {
+      return false;
+    }
+
+    $owner = $object->getAccessDefinitionOwner();
+    $user = $this->getAuthenticatedUser();
+
+    return null !== $owner && null !== $user && $owner->equalAccessDefinitionOwner($user);
+  }
+
+  /**
+   * @return AccessDefinitionOwnerInterface|null
+   */
+  private function getAuthenticatedUser(): ?AccessDefinitionOwnerInterface {
+    $token = $this->tokenStorage->getToken();
+
+    if (null === $token) {
+      return null;
+    }
+
+    $user = $token->getUser();
+
+    if (!$user instanceof AccessDefinitionOwnerInterface) {
+      return null;
+    }
+
+    return $user;
+  }
+
+  /**
+   * @param array $arguments
+   *
+   * @return array
+   */
+  private function checkArguments(array $arguments): array {
+    $context = $arguments['context'] ?? null;
+
+    if (!$context instanceof Context) {
+      throw new \InvalidArgumentException(\sprintf('context missing or not instance of %s', Context::class));
+    }
+
+    $propertyMetadata = $arguments['property_metadata'] ?? null;
+
+    if (!$propertyMetadata instanceof PropertyMetadata) {
+      throw new \InvalidArgumentException(\sprintf('property_metadata missing or not instance of %s', PropertyMetadata::class));
+    }
+
+    $object = $arguments['object'] ?? null;
+
+    return [$context, $propertyMetadata, $object];
+  }
+
+}

--- a/src/AccessDefinitions/JMS/ExpressionLanguage/ExpressionFunction/HasAccessFunction.php
+++ b/src/AccessDefinitions/JMS/ExpressionLanguage/ExpressionFunction/HasAccessFunction.php
@@ -79,7 +79,7 @@ class HasAccessFunction {
     $owner = $object->getAccessDefinitionOwner();
     $user = $this->getAuthenticatedUser();
 
-    return null !== $owner && null !== $user && $owner->equalAccessDefinitionOwner($user);
+    return null !== $owner && null !== $user && $owner->isEqualToAccessDefinitionOwner($user);
   }
 
   /**

--- a/src/AccessDefinitions/JMS/ExpressionLanguage/ExpressionFunction/HasAccessFunction.php
+++ b/src/AccessDefinitions/JMS/ExpressionLanguage/ExpressionFunction/HasAccessFunction.php
@@ -76,7 +76,7 @@ class HasAccessFunction {
       return false;
     }
 
-    $owner = $object->getAccessDefinitionOwner();
+    $owner = $object->getAccessDefinitionObjectOwner();
     $user = $this->getAuthenticatedUser();
 
     return null !== $owner && null !== $user && $owner->isEqualToAccessDefinitionOwner($user);

--- a/src/AccessDefinitions/Metadata/AccessDefinitionClassMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionClassMetadata.php
@@ -14,64 +14,44 @@ use Metadata\MergeableClassMetadata;
 class AccessDefinitionClassMetadata extends MergeableClassMetadata {
 
   /**
-   * @var string[]|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canCreateRoles;
+  public $canCreateEveryone;
 
   /**
-   * @var string[]|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canCreateScopes;
+  public $canReadEveryone;
 
   /**
-   * @var string|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canCreateMethod;
+  public $canUpdateEveryone;
 
   /**
-   * @var string[]|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canReadRoles;
+  public $canDeleteEveryone;
 
   /**
-   * @var string[]|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canReadScopes;
+  public $canCreateOwner;
 
   /**
-   * @var string|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canReadMethod;
+  public $canReadOwner;
 
   /**
-   * @var string[]|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canUpdateRoles;
+  public $canUpdateOwner;
 
   /**
-   * @var string[]|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $canUpdateScopes;
-
-  /**
-   * @var string|null
-   */
-  public $canUpdateMethod;
-
-  /**
-   * @var string[]|null
-   */
-  public $canDeleteRoles;
-
-  /**
-   * @var string[]|null
-   */
-  public $canDeleteScopes;
-
-  /**
-   * @var string|null
-   */
-  public $canDeleteMethod;
+  public $canDeleteOwner;
 
   /**
    * @param string $propertyName
@@ -95,21 +75,45 @@ class AccessDefinitionClassMetadata extends MergeableClassMetadata {
    * @return $this
    */
   public function setClassMetadataFromConfigData(array $data): self {
-    $this->canCreateRoles = $data['canCreate']['roles'] ?? null;
-    $this->canCreateScopes = $data['canCreate']['scopes'] ?? null;
-    $this->canCreateScopes = $data['canCreate']['method'] ?? null;
+    if (isset($data['canCreate']['everyone'])) {
+      $this->canCreateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canCreate']['everyone']);
+    } elseif (isset($data['canCreate'])) {
+      $this->canCreateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canCreate']);
+    }
 
-    $this->canReadRoles = $data['canRead']['roles'] ?? null;
-    $this->canReadScopes = $data['canRead']['scopes'] ?? null;
-    $this->canReadMethod = $data['canRead']['method'] ?? null;
+    if (isset($data['canRead']['everyone'])) {
+      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['everyone']);
+    } elseif (isset($data['canRead'])) {
+      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']);
+    }
 
-    $this->canUpdateRoles = $data['canUpdate']['roles'] ?? null;
-    $this->canUpdateScopes = $data['canUpdate']['scopes'] ?? null;
-    $this->canUpdateMethod = $data['canUpdate']['method'] ?? null;
+    if (isset($data['canUpdate']['everyone'])) {
+      $this->canUpdateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canUpdate']['everyone']);
+    } elseif (isset($data['canUpdate'])) {
+      $this->canUpdateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canUpdate']);
+    }
 
-    $this->canDeleteRoles = $data['canDelete']['roles'] ?? null;
-    $this->canDeleteScopes = $data['canDelete']['scopes'] ?? null;
-    $this->canDeleteMethod = $data['canDelete']['method'] ?? null;
+    if (isset($data['canDelete']['everyone'])) {
+      $this->canDeleteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canDelete']['everyone']);
+    } elseif (isset($data['canDelete'])) {
+      $this->canDeleteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canDelete']);
+    }
+
+    if (isset($data['canCreate']['owner'])) {
+      $this->canCreateOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canCreate']['owner']);
+    }
+
+    if (isset($data['canRead']['owner'])) {
+      $this->canReadOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['owner']);
+    }
+
+    if (isset($data['canUpdate']['owner'])) {
+      $this->canUpdateOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canUpdate']['owner']);
+    }
+
+    if (isset($data['canDelete']['owner'])) {
+      $this->canDeleteOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canDelete']['owner']);
+    }
 
     return $this;
   }
@@ -119,18 +123,14 @@ class AccessDefinitionClassMetadata extends MergeableClassMetadata {
    */
   public function serialize() {
     return serialize([
-      $this->canCreateRoles,
-      $this->canCreateScopes,
-      $this->canCreateMethod,
-      $this->canReadRoles,
-      $this->canReadScopes,
-      $this->canReadMethod,
-      $this->canUpdateRoles,
-      $this->canUpdateScopes,
-      $this->canUpdateMethod,
-      $this->canDeleteRoles,
-      $this->canDeleteScopes,
-      $this->canDeleteMethod,
+      $this->canCreateEveryone,
+      $this->canReadEveryone,
+      $this->canUpdateEveryone,
+      $this->canDeleteEveryone,
+      $this->canCreateOwner,
+      $this->canReadOwner,
+      $this->canUpdateOwner,
+      $this->canDeleteOwner,
       parent::serialize()
     ]);
   }
@@ -141,18 +141,14 @@ class AccessDefinitionClassMetadata extends MergeableClassMetadata {
   public function unserialize($str) {
     $unserialized = unserialize($str);
     [
-      $this->canCreateRoles,
-      $this->canCreateScopes,
-      $this->canCreateMethod,
-      $this->canReadRoles,
-      $this->canReadScopes,
-      $this->canReadMethod,
-      $this->canUpdateRoles,
-      $this->canUpdateScopes,
-      $this->canUpdateMethod,
-      $this->canDeleteRoles,
-      $this->canDeleteScopes,
-      $this->canDeleteMethod,
+      $this->canCreateEveryone,
+      $this->canReadEveryone,
+      $this->canUpdateEveryone,
+      $this->canDeleteEveryone,
+      $this->canCreateOwner,
+      $this->canReadOwner,
+      $this->canUpdateOwner,
+      $this->canDeleteOwner,
       $parentStr
     ] = $unserialized;
 

--- a/src/AccessDefinitions/Metadata/AccessDefinitionClassMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionClassMetadata.php
@@ -4,6 +4,7 @@
 namespace HalloVerden\Security\AccessDefinitions\Metadata;
 
 
+use HalloVerden\Security\Traits\SetAccessDefinitionMetadataTrait;
 use Metadata\MergeableClassMetadata;
 
 /**
@@ -12,6 +13,7 @@ use Metadata\MergeableClassMetadata;
  * @package HalloVerden\Security\AccessDefinitions\Metadata
  */
 class AccessDefinitionClassMetadata extends MergeableClassMetadata {
+  use SetAccessDefinitionMetadataTrait;
 
   /**
    * @var AccessDefinitionMetadata|null
@@ -67,23 +69,6 @@ class AccessDefinitionClassMetadata extends MergeableClassMetadata {
     }
 
     return null;
-  }
-
-  /**
-   * @param array $data
-   *
-   * @return $this
-   */
-  public function setClassMetadataFromConfigData(array $data): self {
-    foreach ($data as $access => $value) {
-      foreach ($value as $type => $v) {
-        if (\property_exists($this, $property = $access . \ucfirst($type))) {
-          $this->$property = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data[$access][$type]);
-        }
-      }
-    }
-
-    return $this;
   }
 
   /**

--- a/src/AccessDefinitions/Metadata/AccessDefinitionClassMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionClassMetadata.php
@@ -75,44 +75,12 @@ class AccessDefinitionClassMetadata extends MergeableClassMetadata {
    * @return $this
    */
   public function setClassMetadataFromConfigData(array $data): self {
-    if (isset($data['canCreate']['everyone'])) {
-      $this->canCreateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canCreate']['everyone']);
-    } elseif (isset($data['canCreate'])) {
-      $this->canCreateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canCreate']);
-    }
-
-    if (isset($data['canRead']['everyone'])) {
-      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['everyone']);
-    } elseif (isset($data['canRead'])) {
-      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']);
-    }
-
-    if (isset($data['canUpdate']['everyone'])) {
-      $this->canUpdateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canUpdate']['everyone']);
-    } elseif (isset($data['canUpdate'])) {
-      $this->canUpdateEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canUpdate']);
-    }
-
-    if (isset($data['canDelete']['everyone'])) {
-      $this->canDeleteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canDelete']['everyone']);
-    } elseif (isset($data['canDelete'])) {
-      $this->canDeleteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canDelete']);
-    }
-
-    if (isset($data['canCreate']['owner'])) {
-      $this->canCreateOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canCreate']['owner']);
-    }
-
-    if (isset($data['canRead']['owner'])) {
-      $this->canReadOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['owner']);
-    }
-
-    if (isset($data['canUpdate']['owner'])) {
-      $this->canUpdateOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canUpdate']['owner']);
-    }
-
-    if (isset($data['canDelete']['owner'])) {
-      $this->canDeleteOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canDelete']['owner']);
+    foreach ($data as $access => $value) {
+      foreach ($value as $type => $v) {
+        if (\property_exists($this, $property = $access . \ucfirst($type))) {
+          $this->$property = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data[$access][$type]);
+        }
+      }
     }
 
     return $this;

--- a/src/AccessDefinitions/Metadata/AccessDefinitionConfiguration.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionConfiguration.php
@@ -54,7 +54,17 @@ class AccessDefinitionConfiguration implements ConfigurationInterface {
 
     $this->addScopesRolesMethodSection($root);
 
-    $root->end();
+    $root->end()->beforeNormalization()->always(function ($value) {
+      // Put all properties that does not specify owner or everyone, in everyone.
+      foreach ($value as $key => $v) {
+        if ($key !== 'owner' && $key !== 'everyone') {
+          $value['everyone'] = [$key => $v];
+          unset($value[$key]);
+        }
+      }
+
+      return $value;
+    });
   }
 
   /**

--- a/src/AccessDefinitions/Metadata/AccessDefinitionConfiguration.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionConfiguration.php
@@ -46,6 +46,12 @@ class AccessDefinitionConfiguration implements ConfigurationInterface {
     $root = $root->arrayNode($name)
       ->children();
 
+    $ownerSection = $root->arrayNode('owner')->children();
+    $this->addScopesRolesMethodSection($ownerSection);
+
+    $everyoneSection = $root->arrayNode('everyone')->children();
+    $this->addScopesRolesMethodSection($everyoneSection);
+
     $this->addScopesRolesMethodSection($root);
 
     $root->end();

--- a/src/AccessDefinitions/Metadata/AccessDefinitionMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionMetadata.php
@@ -31,9 +31,11 @@ class AccessDefinitionMetadata {
    * @return AccessDefinitionMetadata
    */
   public function setMetadataFromConfigData(array $data): self {
-    $this->roles = $data['roles'] ?? null;
-    $this->scopes = $data['scopes'] ?? null;
-    $this->method = $data['method'] ?? null;
+    foreach ($data as $property => $value) {
+      if (\property_exists($this, $property)) {
+        $this->$property = $value;
+      }
+    }
 
     return $this;
   }

--- a/src/AccessDefinitions/Metadata/AccessDefinitionMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionMetadata.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace HalloVerden\Security\AccessDefinitions\Metadata;
+
+/**
+ * Class AccessDefinitionMetadata
+ *
+ * @package HalloVerden\Security\AccessDefinitions\Metadata
+ */
+class AccessDefinitionMetadata {
+
+  /**
+   * @var string[]
+   */
+  public $roles;
+
+  /**
+   * @var string[]
+   */
+  public $scopes;
+
+  /**
+   * @var string|null
+   */
+  public $method;
+
+  /**
+   * @param array $data
+   *
+   * @return AccessDefinitionMetadata
+   */
+  public function setMetadataFromConfigData(array $data): self {
+    $this->roles = $data['roles'] ?? null;
+    $this->scopes = $data['scopes'] ?? null;
+    $this->method = $data['method'] ?? null;
+
+    return $this;
+  }
+
+}

--- a/src/AccessDefinitions/Metadata/AccessDefinitionPropertyMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionPropertyMetadata.php
@@ -4,6 +4,7 @@
 namespace HalloVerden\Security\AccessDefinitions\Metadata;
 
 
+use HalloVerden\Security\Traits\SetAccessDefinitionMetadataTrait;
 use Metadata\PropertyMetadata;
 
 /**
@@ -12,6 +13,7 @@ use Metadata\PropertyMetadata;
  * @package HalloVerden\Security\AccessDefinitions\Metadata
  */
 class AccessDefinitionPropertyMetadata extends PropertyMetadata {
+  use SetAccessDefinitionMetadataTrait;
 
   /**
    * @var AccessDefinitionMetadata|null
@@ -32,35 +34,6 @@ class AccessDefinitionPropertyMetadata extends PropertyMetadata {
    * @var AccessDefinitionMetadata|null
    */
   public $canWriteOwner;
-
-  /**
-   * @param array $data
-   *
-   * @return $this
-   */
-  public function setPropertyMetadataFromConfigData(array $data): self {
-    if (isset($data['canRead']['everyone'])) {
-      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['everyone']);
-    } elseif (isset($data['canRead'])) {
-      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']);
-    }
-
-    if (isset($data['canWrite']['everyone'])) {
-      $this->canWriteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canWrite']['everyone']);
-    } elseif (isset($data['canWrite'])) {
-      $this->canWriteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canWrite']);
-    }
-
-    if (isset($data['canRead']['owner'])) {
-      $this->canReadOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['owner']);
-    }
-
-    if (isset($data['canWrite']['owner'])) {
-      $this->canWriteOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canWrite']['owner']);
-    }
-
-    return $this;
-  }
 
   /**
    * @return string

--- a/src/AccessDefinitions/Metadata/AccessDefinitionPropertyMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionPropertyMetadata.php
@@ -14,34 +14,24 @@ use Metadata\PropertyMetadata;
 class AccessDefinitionPropertyMetadata extends PropertyMetadata {
 
   /**
-   * @var array|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $readRoles;
+  public $canReadEveryone;
 
   /**
-   * @var array|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $writeRoles;
+  public $canWriteEveryone;
 
   /**
-   * @var string|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $readMethod;
+  public $canReadOwner;
 
   /**
-   * @var string|null
+   * @var AccessDefinitionMetadata|null
    */
-  public $writeMethod;
-
-  /**
-   * @var array|null
-   */
-  public $readScopes;
-
-  /**
-   * @var array|null
-   */
-  public $writeScopes;
+  public $canWriteOwner;
 
   /**
    * @param array $data
@@ -49,13 +39,25 @@ class AccessDefinitionPropertyMetadata extends PropertyMetadata {
    * @return $this
    */
   public function setPropertyMetadataFromConfigData(array $data): self {
-    $this->readRoles = $data['canRead']['roles'] ?? null;
-    $this->readScopes = $data['canRead']['scopes'] ?? null;
-    $this->readMethod = $data['canRead']['method'] ?? null;
+    if (isset($data['canRead']['everyone'])) {
+      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['everyone']);
+    } elseif ($data['canRead']) {
+      $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']);
+    }
 
-    $this->writeRoles = $data['canWrite']['roles'] ?? null;
-    $this->writeScopes = $data['canWrite']['scopes'] ?? null;
-    $this->writeMethod = $data['canWrite']['method'] ?? null;
+    if (isset($data['canWrite']['everyone'])) {
+      $this->canWriteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canWrite']['everyone']);
+    } elseif (isset($data['canWrite'])) {
+      $this->canWriteEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canWrite']);
+    }
+
+    if (isset($data['canRead']['owner'])) {
+      $this->canReadOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['owner']);
+    }
+
+    if (isset($data['canWrite']['owner'])) {
+      $this->canWriteOwner = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canWrite']['owner']);
+    }
 
     return $this;
   }
@@ -65,12 +67,10 @@ class AccessDefinitionPropertyMetadata extends PropertyMetadata {
    */
   public function serialize() {
     return serialize([
-      $this->readRoles,
-      $this->writeRoles,
-      $this->readMethod,
-      $this->writeMethod,
-      $this->readScopes,
-      $this->writeScopes,
+      $this->canReadEveryone,
+      $this->canReadOwner,
+      $this->canWriteEveryone,
+      $this->canWriteOwner,
       parent::serialize()
     ]);
   }
@@ -81,12 +81,10 @@ class AccessDefinitionPropertyMetadata extends PropertyMetadata {
   public function unserialize($str) {
     $unserialized = unserialize($str);
     [
-      $this->readRoles,
-      $this->writeRoles,
-      $this->readMethod,
-      $this->writeMethod,
-      $this->readScopes,
-      $this->writeScopes,
+      $this->canReadEveryone,
+      $this->canReadOwner,
+      $this->canWriteEveryone,
+      $this->canWriteOwner,
       $parentStr
     ] = $unserialized;
 

--- a/src/AccessDefinitions/Metadata/AccessDefinitionPropertyMetadata.php
+++ b/src/AccessDefinitions/Metadata/AccessDefinitionPropertyMetadata.php
@@ -41,7 +41,7 @@ class AccessDefinitionPropertyMetadata extends PropertyMetadata {
   public function setPropertyMetadataFromConfigData(array $data): self {
     if (isset($data['canRead']['everyone'])) {
       $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']['everyone']);
-    } elseif ($data['canRead']) {
+    } elseif (isset($data['canRead'])) {
       $this->canReadEveryone = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data['canRead']);
     }
 

--- a/src/AccessDefinitions/Metadata/Drivers/AccessDefinitionYamlDriver.php
+++ b/src/AccessDefinitions/Metadata/Drivers/AccessDefinitionYamlDriver.php
@@ -9,7 +9,6 @@ use HalloVerden\Security\AccessDefinitions\Metadata\AccessDefinitionConfiguratio
 use HalloVerden\Security\AccessDefinitions\Metadata\AccessDefinitionPropertyMetadata;
 use Metadata\ClassMetadata;
 use Metadata\Driver\AbstractFileDriver;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Yaml\Yaml;
 
@@ -37,10 +36,6 @@ class AccessDefinitionYamlDriver extends AbstractFileDriver {
     $metadata->setClassMetadataFromConfigData($data);
 
     foreach ($data['properties'] as $propertyName => $propertyData) {
-      if (!$class->hasProperty($propertyName)) {
-        throw new InvalidConfigurationException(\sprintf('Class %s does not have property %s. Check access definition config %s', $name, $propertyName, $file));
-      }
-
       $propertyMetadata = new AccessDefinitionPropertyMetadata($name, $propertyName);
       $propertyMetadata->setPropertyMetadataFromConfigData($propertyData);
 

--- a/src/AccessDefinitions/Metadata/Drivers/AccessDefinitionYamlDriver.php
+++ b/src/AccessDefinitions/Metadata/Drivers/AccessDefinitionYamlDriver.php
@@ -33,7 +33,7 @@ class AccessDefinitionYamlDriver extends AbstractFileDriver {
 
     $data = $config[$name];
 
-    $metadata->setClassMetadataFromConfigData($data);
+    $metadata->setMetadataFromConfigData($data);
 
     foreach ($data['properties'] as $propertyName => $propertyData) {
       $propertyMetadata = new AccessDefinitionPropertyMetadata($name, $propertyName);

--- a/src/AccessDefinitions/Metadata/Drivers/AccessDefinitionYamlDriver.php
+++ b/src/AccessDefinitions/Metadata/Drivers/AccessDefinitionYamlDriver.php
@@ -37,7 +37,7 @@ class AccessDefinitionYamlDriver extends AbstractFileDriver {
 
     foreach ($data['properties'] as $propertyName => $propertyData) {
       $propertyMetadata = new AccessDefinitionPropertyMetadata($name, $propertyName);
-      $propertyMetadata->setPropertyMetadataFromConfigData($propertyData);
+      $propertyMetadata->setMetadataFromConfigData($propertyData);
 
       $metadata->addPropertyMetadata($propertyMetadata);
     }

--- a/src/Interfaces/AccessDefinitionAccessDeciderServiceInterface.php
+++ b/src/Interfaces/AccessDefinitionAccessDeciderServiceInterface.php
@@ -13,6 +13,6 @@ interface AccessDefinitionAccessDeciderServiceInterface {
    *
    * @return bool
    */
-  public function canHandle(?AccessDefinitionMetadata $metadata): bool;
+  public function hasAccessDefinedAccess(?AccessDefinitionMetadata $metadata): bool;
 
 }

--- a/src/Interfaces/AccessDefinitionAccessDeciderServiceInterface.php
+++ b/src/Interfaces/AccessDefinitionAccessDeciderServiceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace HalloVerden\Security\Interfaces;
+
+
+use HalloVerden\Security\AccessDefinitions\Metadata\AccessDefinitionMetadata;
+
+interface AccessDefinitionAccessDeciderServiceInterface {
+
+  /**
+   * @param AccessDefinitionMetadata|null $metadata
+   *
+   * @return bool
+   */
+  public function canHandle(?AccessDefinitionMetadata $metadata): bool;
+
+}

--- a/src/Interfaces/AccessDefinitionOwnerAwareInterface.php
+++ b/src/Interfaces/AccessDefinitionOwnerAwareInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace HalloVerden\Security\Interfaces;
+
+/**
+ * Interface AccessDefinitionOwnerAwareInterface
+ *
+ * @package HalloVerden\Security\Interfaces
+ */
+interface AccessDefinitionOwnerAwareInterface {
+
+  /**
+   * @return AccessDefinitionOwnerInterface
+   */
+  public function getAccessDefinitionOwner(): ?AccessDefinitionOwnerInterface;
+
+}

--- a/src/Interfaces/AccessDefinitionOwnerAwareInterface.php
+++ b/src/Interfaces/AccessDefinitionOwnerAwareInterface.php
@@ -13,6 +13,6 @@ interface AccessDefinitionOwnerAwareInterface {
   /**
    * @return AccessDefinitionOwnerInterface
    */
-  public function getAccessDefinitionOwner(): ?AccessDefinitionOwnerInterface;
+  public function getAccessDefinitionObjectOwner(): ?AccessDefinitionOwnerInterface;
 
 }

--- a/src/Interfaces/AccessDefinitionOwnerInterface.php
+++ b/src/Interfaces/AccessDefinitionOwnerInterface.php
@@ -15,6 +15,6 @@ interface AccessDefinitionOwnerInterface {
    *
    * @return bool
    */
-  public function equalAccessDefinitionOwner(AccessDefinitionOwnerInterface $owner): bool;
+  public function isEqualToAccessDefinitionOwner(AccessDefinitionOwnerInterface $owner): bool;
 
 }

--- a/src/Interfaces/AccessDefinitionOwnerInterface.php
+++ b/src/Interfaces/AccessDefinitionOwnerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace HalloVerden\Security\Interfaces;
+
+/**
+ * Interface AccessDefinitionOwnerInterface
+ *
+ * @package HalloVerden\Security\Interfaces
+ */
+interface AccessDefinitionOwnerInterface {
+
+  /**
+   * @param AccessDefinitionOwnerInterface $owner
+   *
+   * @return bool
+   */
+  public function equalAccessDefinitionOwner(AccessDefinitionOwnerInterface $owner): bool;
+
+}

--- a/src/Interfaces/AccessDefinitionServiceInterface.php
+++ b/src/Interfaces/AccessDefinitionServiceInterface.php
@@ -12,46 +12,52 @@ interface AccessDefinitionServiceInterface {
 
   /**
    * @param string $class
+   * @param bool   $isOwner
    *
    * @return bool
    */
-  public function canCreate(string $class): bool;
+  public function canCreate(string $class, bool $isOwner = false): bool;
 
   /**
    * @param string $class
+   * @param bool   $isOwner
    *
    * @return bool
    */
-  public function canRead(string $class): bool;
+  public function canRead(string $class, bool $isOwner = false): bool;
 
   /**
    * @param string $class
+   * @param bool   $isOwner
    *
    * @return bool
    */
-  public function canUpdate(string $class): bool;
+  public function canUpdate(string $class, bool $isOwner = false): bool;
 
   /**
    * @param string $class
+   * @param bool   $isOwner
    *
    * @return bool
    */
-  public function canDelete(string $class): bool;
-
-  /**
-   * @param string $class
-   * @param string $property
-   *
-   * @return bool
-   */
-  public function canReadProperty(string $class, string $property): bool;
+  public function canDelete(string $class, bool $isOwner = false): bool;
 
   /**
    * @param string $class
    * @param string $property
+   * @param bool   $isOwner
    *
    * @return bool
    */
-  public function canWriteProperty(string $class, string $property): bool;
+  public function canReadProperty(string $class, string $property, bool $isOwner = false): bool;
+
+  /**
+   * @param string $class
+   * @param string $property
+   * @param bool   $isOwner
+   *
+   * @return bool
+   */
+  public function canWriteProperty(string $class, string $property, bool $isOwner = false): bool;
 
 }

--- a/src/Services/AccessDefinitionAccessDeciderService.php
+++ b/src/Services/AccessDefinitionAccessDeciderService.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace HalloVerden\Security\Services;
+
+
+use HalloVerden\Security\AccessDefinitions\Metadata\AccessDefinitionMetadata;
+use HalloVerden\Security\AccessTokenAuthenticator;
+use HalloVerden\Security\ClientCredentialsAccessTokenAuthenticator;
+use HalloVerden\Security\Interfaces\AccessDefinitionAccessDeciderServiceInterface;
+use HalloVerden\Security\Interfaces\SecurityInterface;
+use HalloVerden\Security\Voters\AuthenticationVoter;
+use HalloVerden\Security\Voters\OauthAuthorizationVoter;
+
+/**
+ * Class AccessDefinitionAccessDeciderService
+ *
+ * @package HalloVerden\Security\Services
+ */
+class AccessDefinitionAccessDeciderService implements AccessDefinitionAccessDeciderServiceInterface {
+
+  /**
+   * @var SecurityInterface
+   */
+  private $security;
+
+  /**
+   * @var array
+   */
+  private $scopeableAuthenticators;
+
+  /**
+   * AccessDefinitionAccessDeciderService constructor.
+   *
+   * @param SecurityInterface $security
+   * @param array|null        $scopeableAuthenticators
+   */
+  public function __construct(SecurityInterface $security, ?array $scopeableAuthenticators = null) {
+    $this->scopeableAuthenticators = $scopeableAuthenticators ?? [AccessTokenAuthenticator::class, ClientCredentialsAccessTokenAuthenticator::class];
+    $this->security = $security;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function canHandle(?AccessDefinitionMetadata $metadata): bool {
+    // Nothing specified = access NOT granted.
+    if (null === $metadata || (null === $metadata->method && null === $metadata->scopes && null === $metadata->roles)) {
+      return false;
+    }
+
+    // If a method is defined, this takes precedence if true.
+    if (null !== $metadata->method && is_callable($metadata->method) && ($metadata->method)($metadata)) {
+      return true;
+    }
+
+    if ($this->shouldCheckScope()) {
+      return $metadata->scopes !== null && $this->security->isGranted(OauthAuthorizationVoter::OAUTH_SCOPE, $metadata->scopes);
+    }
+
+    return null !== $metadata->roles && $this->security->isGrantedEitherOf($metadata->roles);
+  }
+
+  /**
+   * @return bool
+   */
+  private function shouldCheckScope(): bool {
+    // If we where authenticated with a "scopeable" authenticator, we should check scopes.
+    return $this->security->isGranted(AuthenticationVoter::AUTHENTICATOR, $this->scopeableAuthenticators);
+  }
+
+}

--- a/src/Services/AccessDefinitionAccessDeciderService.php
+++ b/src/Services/AccessDefinitionAccessDeciderService.php
@@ -43,7 +43,7 @@ class AccessDefinitionAccessDeciderService implements AccessDefinitionAccessDeci
   /**
    * @inheritDoc
    */
-  public function canHandle(?AccessDefinitionMetadata $metadata): bool {
+  public function hasAccessDefinedAccess(?AccessDefinitionMetadata $metadata): bool {
     // Nothing specified = access NOT granted.
     if (null === $metadata || (null === $metadata->method && null === $metadata->scopes && null === $metadata->roles)) {
       return false;

--- a/src/Services/AccessDefinitionService.php
+++ b/src/Services/AccessDefinitionService.php
@@ -53,11 +53,11 @@ class AccessDefinitionService implements AccessDefinitionServiceInterface {
       return $this->allowNoMetadata;
     }
 
-    if ($isOwner && $this->accessDeciderService->canHandle($metadata->canCreateOwner)) {
+    if ($isOwner && $this->accessDeciderService->hasAccessDefinedAccess($metadata->canCreateOwner)) {
       return true;
     }
 
-    return $this->accessDeciderService->canHandle($metadata->canCreateEveryone);
+    return $this->accessDeciderService->hasAccessDefinedAccess($metadata->canCreateEveryone);
   }
 
   /**
@@ -68,11 +68,11 @@ class AccessDefinitionService implements AccessDefinitionServiceInterface {
       return $this->allowNoMetadata;
     }
 
-    if ($isOwner && $this->accessDeciderService->canHandle($metadata->canReadOwner)) {
+    if ($isOwner && $this->accessDeciderService->hasAccessDefinedAccess($metadata->canReadOwner)) {
       return true;
     }
 
-    return $this->accessDeciderService->canHandle($metadata->canReadEveryone);
+    return $this->accessDeciderService->hasAccessDefinedAccess($metadata->canReadEveryone);
   }
 
   /**
@@ -83,11 +83,11 @@ class AccessDefinitionService implements AccessDefinitionServiceInterface {
       return $this->allowNoMetadata;
     }
 
-    if ($isOwner && $this->accessDeciderService->canHandle($metadata->canUpdateOwner)) {
+    if ($isOwner && $this->accessDeciderService->hasAccessDefinedAccess($metadata->canUpdateOwner)) {
       return true;
     }
 
-    return $this->accessDeciderService->canHandle($metadata->canUpdateEveryone);
+    return $this->accessDeciderService->hasAccessDefinedAccess($metadata->canUpdateEveryone);
   }
 
   /**
@@ -98,11 +98,11 @@ class AccessDefinitionService implements AccessDefinitionServiceInterface {
       return $this->allowNoMetadata;
     }
 
-    if ($isOwner && $this->accessDeciderService->canHandle($metadata->canDeleteOwner)) {
+    if ($isOwner && $this->accessDeciderService->hasAccessDefinedAccess($metadata->canDeleteOwner)) {
       return true;
     }
 
-    return $this->accessDeciderService->canHandle($metadata->canDeleteEveryone);
+    return $this->accessDeciderService->hasAccessDefinedAccess($metadata->canDeleteEveryone);
   }
 
   /**
@@ -113,11 +113,11 @@ class AccessDefinitionService implements AccessDefinitionServiceInterface {
       return $this->allowNoMetadata;
     }
 
-    if ($isOwner && $this->accessDeciderService->canHandle($propertyMetadata->canReadOwner)) {
+    if ($isOwner && $this->accessDeciderService->hasAccessDefinedAccess($propertyMetadata->canReadOwner)) {
       return true;
     }
 
-    return $this->accessDeciderService->canHandle($propertyMetadata->canReadEveryone);
+    return $this->accessDeciderService->hasAccessDefinedAccess($propertyMetadata->canReadEveryone);
   }
 
   /**
@@ -128,11 +128,11 @@ class AccessDefinitionService implements AccessDefinitionServiceInterface {
       return $this->allowNoMetadata;
     }
 
-    if ($isOwner && $this->accessDeciderService->canHandle($propertyMetadata->canWriteOwner)) {
+    if ($isOwner && $this->accessDeciderService->hasAccessDefinedAccess($propertyMetadata->canWriteOwner)) {
       return true;
     }
 
-    return $this->accessDeciderService->canHandle($propertyMetadata->canWriteEveryone);
+    return $this->accessDeciderService->hasAccessDefinedAccess($propertyMetadata->canWriteEveryone);
   }
 
   /**

--- a/src/Traits/SetAccessDefinitionMetadataTrait.php
+++ b/src/Traits/SetAccessDefinitionMetadataTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace HalloVerden\Security\Traits;
+
+
+use HalloVerden\Security\AccessDefinitions\Metadata\AccessDefinitionMetadata;
+
+
+/**
+ * Trait SetAccessDefinitionMetadataTrait
+ *
+ * @package HalloVerden\Security\Traits
+ */
+trait SetAccessDefinitionMetadataTrait {
+
+  /**
+   * @param array $data
+   *
+   * @return $this
+   */
+  public function setMetadataFromConfigData(array $data): self {
+    foreach ($data as $access => $value) {
+      foreach ($value as $type => $v) {
+        if (\property_exists($this, $property = $access . \ucfirst($type))) {
+          $this->$property = (new AccessDefinitionMetadata())->setMetadataFromConfigData($data[$access][$type]);
+        }
+      }
+    }
+
+    return $this;
+  }
+
+}

--- a/src/Voters/AuthenticationVoter.php
+++ b/src/Voters/AuthenticationVoter.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace HalloVerden\Security\Voters;
+
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Guard\AuthenticatorInterface;
+
+/**
+ * Class AuthenticationVoter
+ *
+ * @package HalloVerden\Security\Voters
+ */
+class AuthenticationVoter extends Voter {
+  const AUTHENTICATOR = 'authenticator';
+
+  /**
+   * Determines if the attribute and subject are supported by this voter.
+   *
+   * @param string $attribute An attribute
+   * @param mixed $subjects The subject to secure, e.g. an object the user wants to access or any other PHP type
+   *
+   * @return bool True if the attribute and subject are supported, false otherwise
+   */
+  protected function supports($attribute, $subjects) {
+    if ($attribute !== self::AUTHENTICATOR) {
+      return false;
+    }
+
+    if (!is_array($subjects)) {
+      return false;
+    }
+
+    foreach ($subjects as $subject) {
+      if (is_string($subject) && class_exists($subject) && in_array(AuthenticatorInterface::class, class_implements($subject))) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Perform a single access check operation on a given attribute, subject and token.
+   * It is safe to assume that $attribute and $subject already passed the "supports()" method check.
+   *
+   * @param string $attribute
+   * @param mixed $subjects
+   * @param TokenInterface $token
+   *
+   * @return bool
+   */
+  protected function voteOnAttribute($attribute, $subjects, TokenInterface $token) {
+    if (!$token->hasAttribute(self::AUTHENTICATOR)) {
+      return false;
+    }
+
+    foreach ($subjects as $subject) {
+      if ($token->getAttribute(self::AUTHENTICATOR) === $subject) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+}


### PR DESCRIPTION
- Breaking change: **Yes**

Description:
Adds support for owner/everyone in access definitions.
Example: 
```yaml
App\Entity\User\User:
    properties:
        firstName:
            canRead:
                owner:
                    roles:
                        - 'ROLE_USER'
                everyone:
                    roles:
                        - 'USER_ADMIN'
                    scopes:
                        - 'id.read:users.profile_information'
            canWrite:
                owner:
                    roles:
                        - 'ROLE_USER'
                everyone:
                    roles:
                        - 'USER_ADMIN'
        lastName: /* Missing "owner" and "everyone". Defaults to "everyone". */
            canRead:
                roles:
                    - 'ROLE_USER'
            canWrite:
                roles:
                    - 'ROLE_USER'
```

Adds hasAccess expression language function for JMS serializer.

If the user is authenticated with a "scopeable" authenticator (default to AccessTokenAuthenticator and ClientCredentialsAccessTokenAuthenticator) scopes (and method) is checked. Any other authenticator roles (and method) is checked.